### PR TITLE
Propagate display changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,6 @@ version = "0.1.0"
 dependencies = [
  "rand 0.7.3",
  "serde",
- "serde_json",
  "slog",
  "sloggers",
 ]
@@ -158,6 +157,8 @@ dependencies = [
  "chipotle8",
  "futures",
  "pretty_env_logger",
+ "serde",
+ "serde_json",
  "tokio",
  "warp",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,5 @@ tokio = { version = "0.2", features = ["macros"] }
 warp = "0.2"
 pretty_env_logger = "0.4.0"
 futures = "0.3"
+serde = { version = "1.0.105", features = ["derive"] }
+serde_json = "1.0.51"

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -16,7 +16,7 @@ const height = 32;
 // initialize display and fill with empty pixels
 const display = new Array(width * height);
 for (let i = 0; i < width * height; i++) {
-  display.push(DEAD_COLOR);
+  display.push(0);
 }
 
 // Give the canvas room for all of our cells and a 1px border
@@ -55,8 +55,8 @@ const drawGrid = () => {
   ctx.stroke();
 };
 
-const getIndex = (row: number, column: number) => {
-  return row * width + column;
+const getIndex = (x: number, y: number) => {
+  return y * width + x;
 };
 
 const drawCells = () => {
@@ -64,9 +64,9 @@ const drawCells = () => {
 
   for (let row = 0; row < height; row++) {
     for (let col = 0; col < width; col++) {
-      const idx = getIndex(row, col);
+      const idx = getIndex(col, row);
 
-      ctx.fillStyle = display[idx];
+      ctx.fillStyle = display[idx] === 1 ? ALIVE_COLOR : DEAD_COLOR;
 
       ctx.fillRect(
         col * (CELL_SIZE + 1) + 1,
@@ -105,7 +105,7 @@ function onMessage(event: MessageEvent) {
     for (let change of changes) {
       const { x, y, isAlive } = change;
       const idx = getIndex(x, y);
-      display[idx] = isAlive ? ALIVE_COLOR : DEAD_COLOR;
+      display[idx] ^= isAlive ? 1 : 0;
     }
   }
 }

--- a/lib/messaging.ts
+++ b/lib/messaging.ts
@@ -6,7 +6,7 @@ import { DisplayChange } from "./display_change";
 const messageTypes = ["disconnect", "displaychange", "keydown", "keyup"];
 
 // used so we can calculate its `typeof` and compare it against the type of incoming message data
-const displayChangeExample = [{ x: 0, y: 0, isAlive: true }];
+const displayChangeExample: DisplayChange[] = [{ x: 0, y: 0, isAlive: true }];
 
 /**
  * The types of events we'll receive over the websocket from the server

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,6 @@ async fn user_connected(ws: WebSocket, users: Users) {
 
                     let display_change_message = serde_json::to_string(&DisplayChangeMessage { r#type: "displaychange", changes }).unwrap();
 
-                    println!("sending display change message: {:?}", display_change_message);
                     if let Err(_disconnected) = shared_tx
                         .clone()
                         .lock()


### PR DESCRIPTION
Prior to this diff the Interpreter would run behind its `warp` route, but none of its state would be sent for display on the client. In this PR we emit messages from the server and we handle them on the client.

The client is not very smooth so we'll need to optimize it. The lowest hanging fruit I can think of is moving the websocket connection logic to a service worker and updating a shared `display` array